### PR TITLE
Fix for #31

### DIFF
--- a/RBTray.cpp
+++ b/RBTray.cpp
@@ -102,15 +102,21 @@ static void MinimizeWindowToTray(HWND hwnd) {
         hwnd = GetAncestor(hwnd, GA_ROOT);
     }
 
+    // Hide window before AddWindowToTray call because sometimes RefreshWindowInTray
+    // can be called from inside ShowWindow before program window is actually hidden
+    // and as a result RemoveWindowFromTray is called which immediately removes just
+    // added tray icon.
+    ShowWindow(hwnd, SW_HIDE);
+
     // Add icon to tray if it's not already there
     if (FindInTray(hwnd) == -1) {
         if (!AddWindowToTray(hwnd)) {
-            return;
+          // If there is something wrong with tray icon restore program window.
+          ShowWindow(hwnd, SW_SHOW);
+          SetForegroundWindow(hwnd);
+          return;
         }
     }
-
-    // Hide window
-    ShowWindow(hwnd, SW_HIDE);
 }
 
 static bool RemoveFromTray(int i) {


### PR DESCRIPTION
Normal sequence of events after `Win+Alt+Down` is:
1. MinimizeWindowToTray
2. AddWindowToTray
3. AddToTray

and then `ShowWindow(hwnd, SW_HIDE);` in line https://github.com/benbuck/rbtray/blob/master/RBTray.cpp#L113 is called. Everything works correctly.

On my two computers after this sequence of steps
1. Press `Win+Alt+Down`.
2. Click icon in tray. Program is restored, icon disappears. **VERY IMPORTANT:** don't move your mouse after clicking.
3. Press `Win+Alt+Down`.

I see the same steps 1-3 in program, but from inside of `ShowWindow(hwnd, SW_HIDE);` call `RefreshWindowInTray` is called. Then in line https://github.com/benbuck/rbtray/blob/master/RBTray.cpp#L167 function `IsWindowVisible(hwnd)` returns `TRUE` and then `RemoveWindowFromTray(hwnd);` is called.

To fix the problem we have to hide the program window before `AddWindowToTray` call.