### PR TITLE
Added --no-hook command line option

### DIFF
--- a/RBTray.cpp
+++ b/RBTray.cpp
@@ -292,8 +292,10 @@ LRESULT CALLBACK HookWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) 
                     RestoreWindowFromTray(_hwndItems[i]);
                 }
             }
-            UnRegisterHook();
-            FreeLibrary(_hLib);
+			if (_hLib) {
+				UnRegisterHook();
+				FreeLibrary(_hLib);
+			}
             PostQuitMessage(0);
             break;
         default:
@@ -316,9 +318,13 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*
     int argc;
     LPWSTR * argv = CommandLineToArgvW(GetCommandLineW(), &argc);
     bool shouldExit = false;
+	bool useHook = true;
     for (int a = 0; a < argc; ++a) {
         if (!wcscmp(argv[a], L"--exit")) {
             shouldExit = true;
+        }
+		if (!wcscmp(argv[a], L"--no-hook")) {
+            useHook = false;
         }
     }
 
@@ -332,14 +338,16 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*
         return 0;
     }
 
-    if (!(_hLib = LoadLibrary(L"RBHook.dll"))) {
-        MessageBox(NULL, L"Error loading RBHook.dll.", L"RBTray", MB_OK | MB_ICONERROR);
-        return 0;
-    }
-    if (!RegisterHook(_hLib)) {
-        MessageBox(NULL, L"Error setting hook procedure.", L"RBTray", MB_OK | MB_ICONERROR);
-        return 0;
-    }
+	if (useHook) {
+		if (!(_hLib = LoadLibrary(L"RBHook.dll"))) {
+			MessageBox(NULL, L"Error loading RBHook.dll.", L"RBTray", MB_OK | MB_ICONERROR);
+			return 0;
+		}
+		if (!RegisterHook(_hLib)) {
+			MessageBox(NULL, L"Error setting hook procedure.", L"RBTray", MB_OK | MB_ICONERROR);
+			return 0;
+		}
+	}
 
     WNDCLASS wc;
     wc.style         = 0;

--- a/RBTray.cpp
+++ b/RBTray.cpp
@@ -292,9 +292,9 @@ LRESULT CALLBACK HookWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) 
                     RestoreWindowFromTray(_hwndItems[i]);
                 }
             }
-			if (_hLib) {
-				UnRegisterHook();
-				FreeLibrary(_hLib);
+            if (_hLib) {
+                UnRegisterHook();
+                FreeLibrary(_hLib);
 			}
             PostQuitMessage(0);
             break;
@@ -323,7 +323,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*
         if (!wcscmp(argv[a], L"--exit")) {
             shouldExit = true;
         }
-		if (!wcscmp(argv[a], L"--no-hook")) {
+        if (!wcscmp(argv[a], L"--no-hook")) {
             useHook = false;
         }
     }
@@ -338,16 +338,16 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*
         return 0;
     }
 
-	if (useHook) {
-		if (!(_hLib = LoadLibrary(L"RBHook.dll"))) {
-			MessageBox(NULL, L"Error loading RBHook.dll.", L"RBTray", MB_OK | MB_ICONERROR);
-			return 0;
-		}
-		if (!RegisterHook(_hLib)) {
-			MessageBox(NULL, L"Error setting hook procedure.", L"RBTray", MB_OK | MB_ICONERROR);
-			return 0;
-		}
-	}
+    if (useHook) {
+        if (!(_hLib = LoadLibrary(L"RBHook.dll"))) {
+            MessageBox(NULL, L"Error loading RBHook.dll.", L"RBTray", MB_OK | MB_ICONERROR);
+            return 0;
+        }
+        if (!RegisterHook(_hLib)) {
+            MessageBox(NULL, L"Error setting hook procedure.", L"RBTray", MB_OK | MB_ICONERROR);
+            return 0;
+        }
+    }
 
     WNDCLASS wc;
     wc.style         = 0;

--- a/RBTray.cpp
+++ b/RBTray.cpp
@@ -295,7 +295,7 @@ LRESULT CALLBACK HookWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) 
             if (_hLib) {
                 UnRegisterHook();
                 FreeLibrary(_hLib);
-			}
+            }
             PostQuitMessage(0);
             break;
         default:
@@ -318,7 +318,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*
     int argc;
     LPWSTR * argv = CommandLineToArgvW(GetCommandLineW(), &argc);
     bool shouldExit = false;
-	bool useHook = true;
+    bool useHook = true;
     for (int a = 0; a < argc; ++a) {
         if (!wcscmp(argv[a], L"--exit")) {
             shouldExit = true;


### PR DESCRIPTION
Resolves #38 
Workaround for #33 #13 

Added --no-hook command line option
No mouse hook is installed/uninstalled, RBTray works in hotkey-only mode.